### PR TITLE
Always quote ANONYMIZE_REMOTE_ADDR

### DIFF
--- a/shlink/templates/deployment.yaml
+++ b/shlink/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
               value: {{ .Values.env.BASE_URL_REDIRECT_TO }}
             {{- end }}
             - name: ANONYMIZE_REMOTE_ADDR
-              value: {{ .Values.env.ANONYMIZE_REMOTE_ADDR }}
+              value: {{ .Values.env.ANONYMIZE_REMOTE_ADDR | quote }}
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
The environment var contains a truthiness value, so the YAML/JSON parser will detect it as boolean and will not emit quotes around the value. Newer K8s version require env vars to be strings (or rather: they check to see if they actually are of type string), so when the template renders with true or false it will complain about that not being a string.

Closes: #1 (coincidentally)